### PR TITLE
Missing python_packages parameter

### DIFF
--- a/amun/lib.py
+++ b/amun/lib.py
@@ -72,6 +72,7 @@ def inspect(
     identifier: Optional[str] = None,
     files: Optional[List[Dict[str, Any]]] = None,
     packages: Optional[List[str]] = None,
+    python_packages: Optional[List[str]] = None,
     python: Optional[Dict[str, Any]] = None,
     build: Optional[Dict[str, Any]] = None,
     run: Optional[Dict[str, Any]] = None,
@@ -83,6 +84,7 @@ def inspect(
     specification = InspectionSpecification(
         base=base,
         packages=packages,
+        python_packages=python_packages,
         python=python,
         files=files,
         script=script,


### PR DESCRIPTION
Fixes: https://github.com/thoth-station/amun-client/issues/88

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>